### PR TITLE
Use minimum size for captcha widget

### DIFF
--- a/lib/src/ui/slider_captcha.dart
+++ b/lib/src/ui/slider_captcha.dart
@@ -225,7 +225,7 @@ class _SliderCaptchaState extends State<SliderCaptcha>
 
   @override
   void didChangeDependencies() {
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
       controller.create.call();
     });
     super.didChangeDependencies();

--- a/lib/src/ui/slider_captcha.dart
+++ b/lib/src/ui/slider_captcha.dart
@@ -20,6 +20,7 @@ class SliderCaptcha extends StatefulWidget {
     this.colorCaptChar = Colors.blue,
     this.controller,
     this.borderImager = 0,
+    this.imageToBarPadding = 0,
     Key? key,
   })  : assert(0 <= borderImager && borderImager <= 5),
         super(key: key);
@@ -39,6 +40,10 @@ class SliderCaptcha extends StatefulWidget {
   final double captchaSize;
 
   final SliderController? controller;
+
+  /// Adds space between the captcha image and the slide button bar. 
+  /// Defaults is 0
+  final double imageToBarPadding;
 
   /// to make sure no problems arise, borderImage only allows sheet limit 0 -> 5
   final double borderImager;
@@ -89,6 +94,7 @@ class _SliderCaptchaState extends State<SliderCaptcha>
               ),
             ),
           ),
+          SizedBox(height: widget.imageToBarPadding),
           Container(
             height: heightSliderBar,
             width: double.infinity,

--- a/lib/src/ui/slider_captcha.dart
+++ b/lib/src/ui/slider_captcha.dart
@@ -41,7 +41,7 @@ class SliderCaptcha extends StatefulWidget {
 
   final SliderController? controller;
 
-  /// Adds space between the captcha image and the slide button bar. 
+  /// Adds space between the captcha image and the slide button bar.
   /// Defaults is 0
   final double imageToBarPadding;
 
@@ -223,9 +223,11 @@ class _SliderCaptchaState extends State<SliderCaptcha>
     super.dispose();
   }
 
+  WidgetsBinding? _widgetsBinding() => WidgetsBinding.instance;
+
   @override
   void didChangeDependencies() {
-    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
+    _widgetsBinding()?.addPostFrameCallback((timeStamp) {
       controller.create.call();
     });
     super.didChangeDependencies();

--- a/lib/src/ui/slider_captcha.dart
+++ b/lib/src/ui/slider_captcha.dart
@@ -73,17 +73,20 @@ class _SliderCaptchaState extends State<SliderCaptcha>
     return ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: 500),
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
         children: [
-          ClipRRect(
-            borderRadius: BorderRadius.circular(widget.borderImager),
-            child: TestSliderCaptChar(
-              widget.image,
-              _offsetMove,
-              answerY,
-              colorCaptChar: widget.colorCaptChar,
-              sliderController: _controller,
+          Flexible(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(widget.borderImager),
+              child: TestSliderCaptChar(
+                widget.image,
+                _offsetMove,
+                answerY,
+                colorCaptChar: widget.colorCaptChar,
+                sliderController: _controller,
+              ),
             ),
           ),
           Container(


### PR DESCRIPTION
### In this PR 
- Remove excess space between image and slider bar, allowing `SliderCaptcha` to use the minimum size required, as would be needed in a dialog
- Add `imageToBarPadding` field to `SliderCaptcha` so users can specify how much space suits them
- Fix nullable WidgetsBinding instance 